### PR TITLE
Adding new optional argument to `cvswdetail`: if a value is given, it…

### DIFF
--- a/src/moderncvstylestweaks.sty
+++ b/src/moderncvstylestweaks.sty
@@ -39,6 +39,7 @@
 %\newcommand*{\keyboardsymbol}{\marvosymbol{207}~}
 \newcommand*{\keyboardsymbol}{\faKeyboardO~} %\faLanguage, \faKeyboardO
 \newcommand*{\linksymbol}{{\color{color2}\faArrowCircleRight}~} %\faHandORight, \faArrowCircleORight, \faArrowCircleRight, \faGlobe, \faLink
+\newcommand*{\starsymbol}{\faStarO}
 
 %-------------------------------------------------------------------------------
 %                colors
@@ -113,8 +114,8 @@
   \cvitem[#1]{\myhttplink[\color{black}{\textnormal{\textbf{#2}}}]{#3}}{#4}
   }%
 % And another command for software entries, but this time like cventry:
-% usage: \cvswdetail[spacing]{name of project}{author/copyright}{programming language}{optional: url}{optional: comment/short program description}
-\newcommand*{\cvswdetail}[6][.25em]{%
+% usage: \cvswdetail[spacing]{name of project}{author/copyright}{programming language}{optional: url}{optional: number of stars of project on GitHub}{optional: comment/short program description}
+\newcommand*{\cvswdetail}[7][.25em]{%
   \cvitem[#1]{%
     \ifthenelse{\equal{#5}{}}% no link given:
       {\myurlfont\textnormal{\textbf{#2}}} % without link
@@ -127,9 +128,10 @@
     %{,~{#4}}%programming language used
     %\ifthenelse{\equal{#5}{}}{}{,~\myhttplink[\color{black}{\linksymbol#5}]{#5}}%printed link
     \ifthenelse{\equal{#5}{}}{}{,~{\small\linksymbol}\myhttplink[\color{black}{#5}]{#5}}%printed link
+    \ifthenelse{\equal{#6}{}}{}{,~{\small\starsymbol~\textbf{#6}}}%printed link
     .\strut%
-    \ifx&#6&%description
-      \else{\newline{}\begin{minipage}[t]{\linewidth}\small#6\end{minipage}}\fi}
+    \ifx&#7&%description
+      \else{\newline{}\begin{minipage}[t]{\linewidth}\small#7\end{minipage}}\fi}
     }
 
 


### PR DESCRIPTION
… prints a star symbol and the given string. meant to be used as number of stars for the described software project, e.g. stars of repository on github.